### PR TITLE
feat: make library more compliant to WHATWG Mime Sniffing Standard

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0"?>
 <ruleset>
-	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki"/>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki" />
+
+	<rule ref="MediaWiki.Commenting.FunctionComment.MissingReturn">
+		<severity>0</severity>
+	</rule>
+	<rule ref="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic">
+		<severity>0</severity>
+	</rule>
+	<rule ref="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate">
+		<severity>0</severity>
+	</rule>
+	<rule ref="MediaWiki.Commenting.FunctionComment.MissingParamTag">
+		<severity>0</severity>
+	</rule>
+	<rule ref="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<!-- inherited line limit from MediaWiki is 100; make it at least 120 -->
+			<property name="lineLimit" value="120" />
+		</properties>
+	</rule>
+
 	<file>.</file>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<arg name="bootstrap" value="./vendor/mediawiki/mediawiki-codesniffer/utils/bootstrap-ci.php"/>

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ composer require neoncitylights/media-type
 <?php
 
 use Neoncitylights\MediaType\MediaType;
+use Neoncitylights\MediaType\MediaTypeParser;
 
-$mediaType = MediaType::newFromString( 'text/plain;charset=UTF-8' );
+$parser = new MediaTypeParser();
+$mediaType = $parser->parseOrNull( 'text/plain;charset=UTF-8' );
 
 print( $mediaType->getType() );
 // 'text'

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
 			"url": "https://github.com/sponsors/neoncitylights"
 		}
 	],
+	"require": {
+		"wikimedia/assert": "^0.5.1"
+	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "40.0.0",
 		"mediawiki/minus-x": "1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44cf58f97ff9d824fb0d6bbf7cd3e3e0",
-    "packages": [],
+    "content-hash": "370c999c989baebbb32da76f2d92b9a8",
+    "packages": [
+        {
+            "name": "wikimedia/assert",
+            "version": "v0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/Assert.git",
+                "reference": "27c983fddac1197dc37f6a7cec00fc02861529cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/Assert/zipball/27c983fddac1197dc37f6a7cec00fc02861529cd",
+                "reference": "27c983fddac1197dc37f6a7cec00fc02861529cd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.9"
+            },
+            "require-dev": {
+                "mediawiki/mediawiki-codesniffer": "38.0.0",
+                "mediawiki/minus-x": "1.1.1",
+                "ockcyp/covers-validator": "1.3.3",
+                "php-parallel-lint/php-console-highlighter": "0.5.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.1",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Kinzler"
+                },
+                {
+                    "name": "Thiemo Kreuz"
+                }
+            ],
+            "description": "Provides runtime assertions",
+            "homepage": "https://github.com/wikimedia/Assert",
+            "keywords": [
+                "assert",
+                "assertions",
+                "php",
+                "postcondition",
+                "precondition",
+                "qa"
+            ],
+            "support": {
+                "source": "https://github.com/wikimedia/Assert/tree/v0.5.1"
+            },
+            "time": "2021-12-21T11:46:59+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/semver",
@@ -3158,5 +3217,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -8,10 +8,6 @@ namespace Neoncitylights\MediaType;
  * @license MIT
  */
 class MediaType {
-	public const TOKEN_TYPE_SEPARATOR = '/';
-	public const TOKEN_DELIMETER = ';';
-	public const TOKEN_EQUAL = '=';
-
 	/**
 	 * @see https://mimesniff.spec.whatwg.org/#type
 	 * @var string
@@ -107,7 +103,7 @@ class MediaType {
 	 */
 	public function __toString(): string {
 		$essence = $this->getEssence();
-		if ( empty( $this->getParameters() ) ) {
+		if ( $this->getParameters() === [] ) {
 			return $essence;
 		}
 

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -2,12 +2,14 @@
 
 namespace Neoncitylights\MediaType;
 
+use Stringable;
+
 /**
  * @see https://tools.ietf.org/html/rfc2045
  * @see https://mimesniff.spec.whatwg.org/
  * @license MIT
  */
-class MediaType {
+class MediaType implements Stringable {
 	/**
 	 * @see https://mimesniff.spec.whatwg.org/#type
 	 * @var string

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -8,9 +8,9 @@ namespace Neoncitylights\MediaType;
  * @license MIT
  */
 class MediaType {
-	private const TOKEN_TYPE_SEPARATOR = '/';
-	private const TOKEN_DELIMETER = ';';
-	private const TOKEN_EQUAL = '=';
+	public const TOKEN_TYPE_SEPARATOR = '/';
+	public const TOKEN_DELIMETER = ';';
+	public const TOKEN_EQUAL = '=';
 
 	/**
 	 * @see https://mimesniff.spec.whatwg.org/#type
@@ -39,29 +39,6 @@ class MediaType {
 		$this->type = $type;
 		$this->subType = $subType;
 		$this->parameters = $parameters;
-	}
-
-	/**
-	 * @param string $input
-	 * @return self|null
-	 */
-	public static function newFromString( string $input ): ?self {
-		$trimmedInput = trim( $input );
-		if ( empty( $trimmedInput ) ) {
-			return null;
-		}
-
-		$parts = explode( self::TOKEN_DELIMETER, $trimmedInput );
-		list( $type, $subType ) = explode( self::TOKEN_TYPE_SEPARATOR, $parts[0] );
-		unset( $parts[0] );
-
-		$parameters = [];
-		foreach ( $parts as $part ) {
-			$paramParts = explode( self::TOKEN_EQUAL, $part );
-			$parameters[$paramParts[0]] = $paramParts[1];
-		}
-
-		return new self( $type, $subType, $parameters );
 	}
 
 	/**

--- a/src/MediaTypeParser.php
+++ b/src/MediaTypeParser.php
@@ -2,6 +2,8 @@
 
 namespace Neoncitylights\MediaType;
 
+use Wikimedia\Assert\InvariantException;
+
 class MediaTypeParser {
 	public function parseOrNull( string $s ): MediaType|null {
 		try {
@@ -11,6 +13,9 @@ class MediaTypeParser {
 		}
 	}
 
+	/**
+	 * @throws MediaTypeParserException|InvariantException
+	 */
 	public function parse( string $s ): MediaType {
 		$normalized = Utf8Utils::trimHttpWhitespace( $s );
 		if ( $normalized === '' ) {
@@ -27,6 +32,9 @@ class MediaTypeParser {
 		return new MediaType( $type, $subType, $parameters );
 	}
 
+	/**
+	 * @throws MediaTypeParserException
+	 */
 	private function collectType( string $s, int $length, int &$position ): string {
 		$type = Utf8Utils::collectCodepoints(
 			$s, $position,
@@ -52,6 +60,9 @@ class MediaTypeParser {
 		return \strtolower( $type );
 	}
 
+	/**
+	 * @throws MediaTypeParserException
+	 */
 	private function collectSubType( string $s, int &$position ): string {
 		$subType = Utf8Utils::collectCodepoints(
 			$s, $position,
@@ -72,6 +83,9 @@ class MediaTypeParser {
 		return \strtolower( $subType );
 	}
 
+	/**
+	 * @throws MediaTypeParserException|InvariantException
+	 */
 	private function collectParameters( string $s, int $length, int &$position ): array {
 		$parameters = [];
 		while ( $position < $length ) {
@@ -104,7 +118,7 @@ class MediaTypeParser {
 			// collect parameter value
 			$parameterValue = null;
 			if ( $s[$position] === '"' ) {
-				$parameterValue = Utf8Utils::collectCodepoints( $s, $position, fn() => true );
+				$parameterValue = Utf8Utils::collectHttpQuotedString( $s, $position, true );
 				Utf8Utils::collectCodepoints( $s, $position, fn( string $c ) => $c !== Token::Semicolon->value );
 			} else {
 				$parameterValue = Utf8Utils::collectCodepoints( $s, $position,

--- a/src/MediaTypeParser.php
+++ b/src/MediaTypeParser.php
@@ -49,13 +49,13 @@ class MediaTypeParser {
 			// skip whitespace
 			Utf8Utils::collectCodePoints(
 				$s, $position,
-				fn(string $c) => Utf8Utils::isHttpWhitespace( $c )
+				fn( string $c ) => Utf8Utils::isHttpWhitespace( $c )
 			);
 
 			// collect parameter name
 			$parameterName = Utf8Utils::collectCodePoints(
 				$s, $position,
-				fn(string $c) => $c === ';' || $c === '='
+				fn( string $c ) => $c === ';' || $c === '='
 			);
 			$parameterName = \strtolower( $parameterName );
 
@@ -78,7 +78,7 @@ class MediaTypeParser {
 			} else {
 				$parameterValue = Utf8Utils::collectCodePoints( $s, $position, fn( string $c ) => $c !== ';' );
 				$parameterValue = Utf8Utils::trimHttpWhitespace( $parameterValue );
-				if( $parameterValue === '' ) {
+				if ( $parameterValue === '' ) {
 					continue;
 				}
 			}

--- a/src/MediaTypeParser.php
+++ b/src/MediaTypeParser.php
@@ -123,7 +123,7 @@ class MediaTypeParser {
 					fn( string $c ) => Utf8Utils::isHttpTokenCodepoint( $c ) )
 				&& Utf8Utils::onlyContains( $parameterValue,
 					fn( string $c ) => Utf8Utils::isHttpQuotedStringTokenCodepoint( $c ) )
-				&& isset( $parameters[$parameterValue] )
+				&& !isset( $parameters[$parameterName] )
 			) {
 				$parameters[$parameterName] = $parameterValue;
 			}

--- a/src/MediaTypeParser.php
+++ b/src/MediaTypeParser.php
@@ -2,13 +2,14 @@
 
 namespace Neoncitylights\MediaType;
 
+use Wikimedia\Assert\AssertionException;
 use Wikimedia\Assert\InvariantException;
 
 class MediaTypeParser {
 	public function parseOrNull( string $s ): MediaType|null {
 		try {
 			return $this->parse( $s );
-		} catch ( MediaTypeParserException ) {
+		} catch ( MediaTypeParserException | AssertionException ) {
 			return null;
 		}
 	}

--- a/src/MediaTypeParser.php
+++ b/src/MediaTypeParser.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Neoncitylights\MediaType;
+
+class MediaTypeParser {
+	public function parse( string $s ) {
+		$length = strlen( $s );
+		$normalized = Utf8Utils::trimHttpWhitespace( $s );
+		$position = 0;
+
+		$type = $this->collectType( $normalized, $length, $position );
+		$subType = $this->collectSubType( $normalized, $length, $position );
+		$parameters = $this->collectParameters( $s, $length, $position );
+
+		return new MediaType( $type, $subType, $parameters );
+	}
+
+	private function collectType( string $s, int $length, int &$position ): string {
+		$type = Utf8Utils::collectCodePoints(
+			$s, $position,
+			fn( string $c ) => $c === MediaType::TOKEN_TYPE_SEPARATOR
+		);
+		if ( $position > $length ) {
+			throw new MediaTypeParserException();
+		}
+		$position++;
+
+		return $type;
+	}
+
+	private function collectSubType( string $s, int &$position ): string {
+		$subType = Utf8Utils::collectCodePoints(
+			$s, $position,
+			fn( string $c ) => $c === MediaType::TOKEN_DELIMETER
+		);
+		$subType = Utf8Utils::trimHttpWhitespace( $subType );
+		if ( $subType === '' ) {
+			throw new MediaTypeParserException();
+		}
+
+		return $subType;
+	}
+
+	private function collectParameters( string $s, int $length, int &$position ): array {
+		$parameters = [];
+		while ( $position < $length ) {
+			$position++;
+
+			// skip whitespace
+			Utf8Utils::collectCodePoints(
+				$s, $position,
+				fn(string $c) => Utf8Utils::isHttpWhitespace( $c )
+			);
+
+			// collect parameter name
+			$parameterName = Utf8Utils::collectCodePoints(
+				$s, $position,
+				fn(string $c) => $c === ';' || $c === '='
+			);
+			$parameterName = \strtolower( $parameterName );
+
+			// skip parameter delimiters
+			if ( $position < $length ) {
+				if ( $s[$position] === ';' ) {
+					continue;
+				}
+				$position++;
+			}
+			if ( $position > $length ) {
+				break;
+			}
+
+			// collect parameter value
+			$parameterValue = null;
+			if ( $s[$position] === '"' ) {
+				$parameterValue = Utf8Utils::collectCodePoints( $s, $position, fn() => true );
+				Utf8Utils::collectCodePoints( $s, $position, fn( string $c ) => $c !== ';' );
+			} else {
+				$parameterValue = Utf8Utils::collectCodePoints( $s, $position, fn( string $c ) => $c !== ';' );
+				$parameterValue = Utf8Utils::trimHttpWhitespace( $parameterValue );
+				if( $parameterValue === '' ) {
+					continue;
+				}
+			}
+
+			// check that parameter name and parameter values are valid
+			if (
+				$parameterName !== ''
+				&& Utf8Utils::onlyContains( $parameterName,
+					fn( string $c ) => Utf8Utils::isHttpTokenCodepoint( $c ) )
+				&& Utf8Utils::onlyContains( $parameterValue,
+					fn( string $c ) => Utf8Utils::isHttpQuotedStringTokenCodepoint( $c ) )
+				&& isset( $parameters[$parameterValue] )
+			) {
+				$parameters[$parameterName] = $parameterValue;
+			}
+		}
+
+		return $parameters;
+	}
+}

--- a/src/MediaTypeParser.php
+++ b/src/MediaTypeParser.php
@@ -5,6 +5,9 @@ namespace Neoncitylights\MediaType;
 use Wikimedia\Assert\AssertionException;
 use Wikimedia\Assert\InvariantException;
 
+/**
+ * @see https://mimesniff.spec.whatwg.org/#parsing-a-mime-type
+ */
 class MediaTypeParser {
 	public function parseOrNull( string $s ): MediaType|null {
 		try {
@@ -53,7 +56,7 @@ class MediaTypeParser {
 		}
 
 		if ( $position > $length ) {
-			throw new MediaTypeParserException( "type: position > lenght" );
+			throw new MediaTypeParserException( "type: position > length" );
 		}
 
 		$position++;
@@ -85,7 +88,7 @@ class MediaTypeParser {
 	}
 
 	/**
-	 * @throws MediaTypeParserException|InvariantException
+	 * @throws InvariantException
 	 */
 	private function collectParameters( string $s, int $length, int &$position ): array {
 		$parameters = [];
@@ -138,7 +141,7 @@ class MediaTypeParser {
 					fn( string $c ) => Utf8Utils::isHttpTokenCodepoint( $c ) )
 				&& Utf8Utils::onlyContains( $parameterValue,
 					fn( string $c ) => Utf8Utils::isHttpQuotedStringTokenCodepoint( $c ) )
-				&& !isset( $parameters[$parameterName] )
+				&& !\array_key_exists( $parameterName, $parameters )
 			) {
 				$parameters[$parameterName] = $parameterValue;
 			}

--- a/src/MediaTypeParserException.php
+++ b/src/MediaTypeParserException.php
@@ -4,4 +4,5 @@ namespace Neoncitylights\MediaType;
 
 use Exception;
 
-class MediaTypeParserException extends Exception {}
+class MediaTypeParserException extends Exception {
+}

--- a/src/MediaTypeParserException.php
+++ b/src/MediaTypeParserException.php
@@ -4,5 +4,8 @@ namespace Neoncitylights\MediaType;
 
 use Exception;
 
+/**
+ * @license MIT
+ */
 class MediaTypeParserException extends Exception {
 }

--- a/src/MediaTypeParserException.php
+++ b/src/MediaTypeParserException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Neoncitylights\MediaType;
+
+use Exception;
+
+class MediaTypeParserException extends Exception {}

--- a/src/Token.php
+++ b/src/Token.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Neoncitylights\MediaType;
+
+/**
+ * @internal
+ * @license MIT
+ */
+enum Token: string {
+	case Slash = '/';
+	case Semicolon = ';';
+	case Equal = '=';
+}

--- a/src/Utf8Utils.php
+++ b/src/Utf8Utils.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Neoncitylights\MediaType;
+
+/**
+ * @license MIT
+ */
+class Utf8Utils {
+	public static function onlyContains( string $input, callable $predicateFn): string {
+		for ( $i = 0; $i < \strlen( $input ); $i++ ) {
+			if ( !$predicateFn( $input[$i] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public static function collectCodePoints( string $input, int &$position, callable $predicateFn ): string {
+        $result = '';
+        while (
+            $position < \strlen( $position)
+            && $input[$position] == $predicateFn( $input )
+        ) {
+            $result += $input[$position];
+            $position++;
+        }
+
+        return $result;
+    }
+
+	public static function trimHttpWhitespace( string $s ): bool {
+		$leadingIndex = 0;
+		while ( self::isHttpWhitespace( $s[$leadingIndex] ) ) {
+			$leadingIndex++;
+		}
+	
+		$trailingIndex = \strlen( $s );
+		while ( self::isHttpWhitespace( $s[$trailingIndex - 1] ) ) {
+			$trailingIndex--;
+		}
+	
+		return \substr( $s, $leadingIndex, $trailingIndex );
+	}
+
+	/**
+	 * @see https://mimesniff.spec.whatwg.org/#http-token-code-point
+	 */
+	public static function isHttpTokenCodepoint( int $codePoint ): bool {
+		return $codePoint === 0x21
+			|| self::isCodePointBetween( $codePoint, 0x23, 0x27 )
+			|| $codePoint === 0x2A || $codePoint === 0x2B
+			|| $codePoint === 0x2D || $codePoint === 0x2E
+			|| self::isCodePointBetween( $codePoint, 0x5E, 0x60 )
+			|| $codePoint === 0x7C || $codePoint === 0x7E;
+	}
+
+	/**
+	 * @see https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
+	 */
+	public static function isHttpQuotedStringTokenCodepoint( int $codePoint ): bool {
+		return self::isCodePointBetween( $codePoint, 0x20, 0x21 )
+			|| self::isCodePointBetween( $codePoint, 0x23, 0x5B )
+			|| self::isCodePointBetween( $codePoint, 0x5D, 0x7E );
+	}
+
+	/**
+	 * @see https://fetch.spec.whatwg.org/#http-whitespace
+	 */
+	public static function isHttpWhitespace( int $codePoint ): bool {
+		return $codePoint === 0x0A || $codePoint === 0x0D
+			|| $codePoint === 0x09 || $codePoint === 0x20;
+	}
+
+	/**
+	 * @see https://fetch.spec.whatwg.org/#http-tab-or-space-byte
+	 */
+	public static function isHttpTabOrSpace( int $codePoint ): bool {
+		return $codePoint === 0x09 || $codePoint === 0x20;
+	}
+
+	private static function isCodePointBetween( int $codePoint, int $lowerBound, int $upperBound ): bool {
+		return $codePoint >= $lowerBound && $codePoint <= $upperBound;
+	}
+}

--- a/src/Utf8Utils.php
+++ b/src/Utf8Utils.php
@@ -6,7 +6,7 @@ namespace Neoncitylights\MediaType;
  * @license MIT
  */
 class Utf8Utils {
-	public static function onlyContains( string $input, callable $predicateFn): string {
+	public static function onlyContains( string $input, callable $predicateFn ): string {
 		for ( $i = 0; $i < \strlen( $input ); $i++ ) {
 			if ( !$predicateFn( $input[$i] ) ) {
 				return false;
@@ -17,29 +17,29 @@ class Utf8Utils {
 	}
 
 	public static function collectCodePoints( string $input, int &$position, callable $predicateFn ): string {
-        $result = '';
-        while (
-            $position < \strlen( $position)
-            && $input[$position] == $predicateFn( $input )
-        ) {
-            $result += $input[$position];
-            $position++;
-        }
+		$result = '';
+		while (
+			$position < \strlen( $position )
+			&& $input[$position] == $predicateFn( $input )
+		) {
+			$result += $input[$position];
+			$position++;
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
 	public static function trimHttpWhitespace( string $s ): bool {
 		$leadingIndex = 0;
 		while ( self::isHttpWhitespace( $s[$leadingIndex] ) ) {
 			$leadingIndex++;
 		}
-	
+
 		$trailingIndex = \strlen( $s );
 		while ( self::isHttpWhitespace( $s[$trailingIndex - 1] ) ) {
 			$trailingIndex--;
 		}
-	
+
 		return \substr( $s, $leadingIndex, $trailingIndex );
 	}
 

--- a/tests/MediaTypeParserTest.php
+++ b/tests/MediaTypeParserTest.php
@@ -77,6 +77,14 @@ class MediaTypeParserTest extends TestCase {
 				],
 			],
 			[
+				"text/plain;charset=\"UTF-8\"",
+				'text',
+				'plain',
+				[
+					'charset' => "UTF-8",
+				],
+			],
+			[
 				'TexT/PlAin',
 				'text',
 				'plain',

--- a/tests/MediaTypeParserTest.php
+++ b/tests/MediaTypeParserTest.php
@@ -77,6 +77,18 @@ class MediaTypeParserTest extends TestCase {
 				],
 			],
 			[
+				'TexT/PlAin',
+				'text',
+				'plain',
+				[]
+			],
+			[
+				'text/ plain ',
+				'text',
+				'plain',
+				[],
+			],
+			[
 				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 				'application',
 				'vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -91,6 +103,10 @@ class MediaTypeParserTest extends TestCase {
 			[ '    ' ],
 			[ '\n\n\n\n\r\r\r' ],
 			[ 'text' ],
+			[ 'tex\t/plain' ],
+			[ 'text/pla\in' ],
+			[ '/plain' ],
+			[ 'text/' ],
 		];
 	}
 }

--- a/tests/MediaTypeParserTest.php
+++ b/tests/MediaTypeParserTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Neoncitylights\MediaType\Tests;
+
+use Neoncitylights\MediaType\MediaTypeParser;
+use Neoncitylights\MediaType\MediaTypeParserException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Neoncitylights\MediaType\MediaTypeParser
+ */
+class MediaTypeTest extends TestCase {
+    /**
+     * @covers ::__construct
+     */
+    public function testConstructor() {
+        $this->assertInstanceOf(
+            MediaTypeParser::class,
+            new MediaTypeParser()
+        );
+    }
+}

--- a/tests/MediaTypeParserTest.php
+++ b/tests/MediaTypeParserTest.php
@@ -25,14 +25,14 @@ class MediaTypeParserTest extends TestCase {
 		string $validMediaType,
 		string $expectedType,
 		string $expectedSubType,
-		// array $expectedParameters
+		array $expectedParameters
 	): void {
 		$parsedValue = $this->parser->parse( $validMediaType );
 
 		$this->assertInstanceOf( MediaType::class, $parsedValue );
 		$this->assertEquals( $expectedType, $parsedValue->getType() );
 		$this->assertEquals( $expectedSubType, $parsedValue->getSubType() );
-		// $this->assertEquals( $expectedParameters, $parsedValue->getParameters() );
+		$this->assertEquals( $expectedParameters, $parsedValue->getParameters() );
 	}
 
 	/**
@@ -50,37 +50,37 @@ class MediaTypeParserTest extends TestCase {
 				'text/plain',
 				'text',
 				'plain',
-				// [],
+				[],
 			],
 			[
 				'text/plain;charset=UTF-8',
 				'text',
 				'plain',
-				// [
-				// 	'charset' => 'UTF-8',
-				// ],
+				[
+					'charset' => 'UTF-8',
+				],
 			],
 			[
 				'  text/plain;charset=UTF-8  ',
 				'text',
 				'plain',
-				// [
-				// 	'charset' => 'UTF-8',
-				// ],
+				[
+					'charset' => 'UTF-8',
+				],
 			],
 			[
 				'  text/plain;   charset=UTF-8  ',
 				'text',
 				'plain',
-				// [
-				// 	'charset' => 'UTF-8',
-				// ],
+				[
+					'charset' => 'UTF-8',
+				],
 			],
 			[
 				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 				'application',
 				'vnd.openxmlformats-officedocument.presentationml.presentation',
-				// [],
+				[],
 			]
 		];
 	}

--- a/tests/MediaTypeTest.php
+++ b/tests/MediaTypeTest.php
@@ -45,45 +45,61 @@ class MediaTypeTest extends TestCase {
 	 * @covers ::getEssence
 	 * @dataProvider provideEssences
 	 */
-	public function testGetEssence(  string $type, string $subType, string $expectedEssence ): void {
+	public function testGetEssence( string $type, string $subType, string $expectedEssence ): void {
 		$this->assertEquals(
 			$expectedEssence,
 			( new MediaType( $type, $subType, [] ) )->getEssence()
 		);
 	}
 
-	// /**
-	//  * @covers ::getParameters
-	//  * @dataProvider provideParameters
-	//  */
-	// public function testGetParameters( $expectedParameters, $mediaType ): void {
-	// 	$this->assertEquals(
-	// 		$expectedParameters,
-	// 		MediaType::newFromString( $mediaType )->getParameters()
-	// 	);
-	// }
+	/**
+	 * @covers ::getParameters
+	 * @dataProvider provideParameters
+	 */
+	public function testGetParameters(
+		string $type,
+		string $subType,
+		array $givenParameters,
+		array $expectedParameters
+	): void {
+		$this->assertEquals(
+			$expectedParameters,
+			( new MediaType( $type, $subType, $givenParameters ) )->getParameters()
+		);
+	}
 
-	// /**
-	//  * @covers ::getParameterValue
-	//  * @dataProvider provideParameterValues
-	//  */
-	// public function testGetParameterValue( $expectedParameterValue, $parameterName, $mediaType ): void {
-	// 	$this->assertEquals(
-	// 		$expectedParameterValue,
-	// 		MediaType::newFromString( $mediaType )->getParameterValue( $parameterName )
-	// 	);
-	// }
+	/**
+	 * @covers ::getParameterValue
+	 * @dataProvider provideParameterValues
+	 */
+	public function testGetParameterValue(
+		string $type,
+		string $subType,
+		array $givenParameters,
+		string $parameterName,
+		string|null $expectedParameterValue
+	): void {
+		$this->assertEquals(
+			$expectedParameterValue,
+			( new MediaType( $type, $subType, $givenParameters ) )->getParameterValue( $parameterName )
+		);
+	}
 
-	// /**
-	//  * @covers ::__toString
-	//  * @dataProvider provideStrings
-	//  */
-	// public function testToString( $expectedString, $mediaType ): void {
-	// 	$this->assertEquals(
-	// 		$expectedString,
-	// 		(string)MediaType::newFromString( $mediaType )
-	// 	);
-	// }
+	/**
+	 * @covers ::__toString
+	 * @dataProvider provideStrings
+	 */
+	public function testToString(
+		string $type,
+		string $subType,
+		array $givenParameters,
+		string $expectedString
+	): void {
+		$this->assertEquals(
+			$expectedString,
+			(string)new MediaType( $type, $subType, $givenParameters )
+		);
+	}
 
 	public function provideInvalidMediaTypes() {
 		return [
@@ -148,12 +164,16 @@ class MediaTypeTest extends TestCase {
 	public function provideParameters() {
 		return [
 			[
+				'text',
+				'plain',
 				[ 'charset' => 'UTF-8' ],
-				'text/plain;charset=UTF-8',
+				[ 'charset' => 'UTF-8' ],
 			],
 			[
+				'text',
+				'plain',
 				[],
-				'text/plain',
+				[],
 			],
 		];
 	}
@@ -161,14 +181,18 @@ class MediaTypeTest extends TestCase {
 	public function provideParameterValues() {
 		return [
 			[
-				'UTF-8',
+				'text',
+				'plain',
+				[ 'charset' => 'UTF-8' ],
 				'charset',
-				'text/plain;charset=UTF-8',
+				'UTF-8'
 			],
 			[
-				null,
+				'text',
+				'plain',
+				[],
 				'charset',
-				'text/plain',
+				null,
 			]
 		];
 	}
@@ -176,15 +200,21 @@ class MediaTypeTest extends TestCase {
 	public function provideStrings() {
 		return [
 			[
-				'text/input',
+				'text',
+				'input',
+				[],
 				'text/input',
 			],
 			[
-				'text/plain;charset=UTF-8',
+				'text',
+				'plain',
+				[ 'charset' => 'UTF-8' ],
 				'text/plain;charset=UTF-8',
 			],
 			[
-				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+				'application',
+				'vnd.openxmlformats-officedocument.presentationml.presentation',
+				[],
 				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 			]
 		];

--- a/tests/MediaTypeTest.php
+++ b/tests/MediaTypeTest.php
@@ -212,6 +212,12 @@ class MediaTypeTest extends TestCase {
 				'text/plain;charset=UTF-8',
 			],
 			[
+				'text',
+				'plain',
+				[ 'param' => '' ],
+				"text/plain;param=\"\"",
+			],
+			[
 				'application',
 				'vnd.openxmlformats-officedocument.presentationml.presentation',
 				[],

--- a/tests/MediaTypeTest.php
+++ b/tests/MediaTypeTest.php
@@ -20,29 +20,13 @@ class MediaTypeTest extends TestCase {
 	}
 
 	/**
-	 * @covers ::newFromString
-	 * @dataProvider provideValidMediaTypes
-	 */
-	public function testIsValidMediaType( $validMediaType ): void {
-		$this->assertInstanceOf( MediaType::class, MediaType::newFromString( $validMediaType ) );
-	}
-
-	/**
-	 * @covers ::newFromString
-	 * @dataProvider provideInvalidMediaTypes
-	 */
-	public function testIsInvalidMediaTypeObject ( $invalidMediaType ): void {
-		$this->assertNull( MediaType::newFromString( $invalidMediaType ) );
-	}
-
-	/**
 	 * @covers ::getType
 	 * @dataProvider provideTypes
 	 */
-	public function testGetType( $expectedType, $actualType ): void {
+	public function testGetType( string $subType, string $type ): void {
 		$this->assertEquals(
-			$expectedType,
-			MediaType::newFromString( $actualType )->getType()
+			$type,
+			( new MediaType( $type, $subType, [] ) )->getType()
 		);
 	}
 
@@ -50,10 +34,10 @@ class MediaTypeTest extends TestCase {
 	 * @covers ::getSubType
 	 * @dataProvider provideSubTypes
 	 */
-	public function testGetSubType( $expectedSubType, $actualSubType ): void {
+	public function testGetSubType( string $subType, string $type ): void {
 		$this->assertEquals(
-			$expectedSubType,
-			MediaType::newFromString( $actualSubType )->getSubType()
+			$subType,
+			( new MediaType( $type, $subType, [] ) )->getSubType()
 		);
 	}
 
@@ -61,54 +45,45 @@ class MediaTypeTest extends TestCase {
 	 * @covers ::getEssence
 	 * @dataProvider provideEssences
 	 */
-	public function testGetEssence( $expectedEssence, $actualEssence ): void {
+	public function testGetEssence(  string $type, string $subType, string $expectedEssence ): void {
 		$this->assertEquals(
 			$expectedEssence,
-			MediaType::newFromString( $actualEssence )->getEssence()
+			( new MediaType( $type, $subType, [] ) )->getEssence()
 		);
 	}
 
-	/**
-	 * @covers ::getParameters
-	 * @dataProvider provideParameters
-	 */
-	public function testGetParameters( $expectedParameters, $mediaType ): void {
-		$this->assertEquals(
-			$expectedParameters,
-			MediaType::newFromString( $mediaType )->getParameters()
-		);
-	}
+	// /**
+	//  * @covers ::getParameters
+	//  * @dataProvider provideParameters
+	//  */
+	// public function testGetParameters( $expectedParameters, $mediaType ): void {
+	// 	$this->assertEquals(
+	// 		$expectedParameters,
+	// 		MediaType::newFromString( $mediaType )->getParameters()
+	// 	);
+	// }
 
-	/**
-	 * @covers ::getParameterValue
-	 * @dataProvider provideParameterValues
-	 */
-	public function testGetParameterValue( $expectedParameterValue, $parameterName, $mediaType ): void {
-		$this->assertEquals(
-			$expectedParameterValue,
-			MediaType::newFromString( $mediaType )->getParameterValue( $parameterName )
-		);
-	}
+	// /**
+	//  * @covers ::getParameterValue
+	//  * @dataProvider provideParameterValues
+	//  */
+	// public function testGetParameterValue( $expectedParameterValue, $parameterName, $mediaType ): void {
+	// 	$this->assertEquals(
+	// 		$expectedParameterValue,
+	// 		MediaType::newFromString( $mediaType )->getParameterValue( $parameterName )
+	// 	);
+	// }
 
-	/**
-	 * @covers ::__toString
-	 * @dataProvider provideStrings
-	 */
-	public function testToString( $expectedString, $mediaType ): void {
-		$this->assertEquals(
-			$expectedString,
-			(string)MediaType::newFromString( $mediaType )
-		);
-	}
-
-	public function provideValidMediaTypes() {
-		return [
-			[ 'text/plain;charset=UTF-8' ],
-			[ 'application/xhtml+xml' ],
-			[ 'application/vnd.openxmlformats-officedocument.presentationml.presentation' ],
-			[ '\n\r\t\0\x0Btext/plain\n\r\t\0\x0B' ],
-		];
-	}
+	// /**
+	//  * @covers ::__toString
+	//  * @dataProvider provideStrings
+	//  */
+	// public function testToString( $expectedString, $mediaType ): void {
+	// 	$this->assertEquals(
+	// 		$expectedString,
+	// 		(string)MediaType::newFromString( $mediaType )
+	// 	);
+	// }
 
 	public function provideInvalidMediaTypes() {
 		return [
@@ -153,15 +128,18 @@ class MediaTypeTest extends TestCase {
 	public function provideEssences() {
 		return [
 			[
-				'text/plain',
+				'text',
+				'plain',
 				'text/plain',
 			],
 			[
-				'application/xhtml+xml',
+				'application',
+				'xhtml+xml',
 				'application/xhtml+xml',
 			],
 			[
-				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+				'application',
+				'vnd.openxmlformats-officedocument.presentationml.presentation',
 				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 			],
 		];

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Neoncitylights\MediaType\Tests;
+
+use Neoncitylights\MediaType\Token;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Neoncitylights\MediaType\Token
+ */
+class TokenTest extends TestCase {
+    /**
+     * @coversNothing
+     */
+    public function testEnumMemberValues(): void {
+        $this->assertEquals( ';', Token::Semicolon->value );
+        $this->assertEquals( '=', Token::Equal->value );
+        $this->assertEquals( '/', Token::Slash->value );
+    }
+}

--- a/tests/Utf8UtilsTest.php
+++ b/tests/Utf8UtilsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Neoncitylights\MediaType\Tests;
+
+use Neoncitylights\MediaType\Utf8Utils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Neoncitylights\MediaType\Utf8Utils
+ */
+class Utf8UtilsTest extends TestCase {
+	/**
+	 * @covers ::trimHttpWhitespace
+	 * @dataProvider provideTrimHttpWhitespace
+	 */
+	public function testTrimHttpWhitespace(
+		string $inputValue,
+		string $expectedOutputValue
+	): void {
+		$this->assertEquals(
+			$expectedOutputValue,
+			Utf8Utils::trimHttpWhitespace( $inputValue )
+		);
+	}
+
+	/**
+	 * @covers ::collectCodepoints
+	 * @dataProvider provideCollectCodepoints
+	 */
+	public function testCollectCodepoints(
+		string $originalString,
+		int $originalPosition,
+		string $newString,
+		int $newPosition,
+		\Closure $predicateFn
+	): void {
+		$position = $originalPosition;
+
+		$this->assertEquals(
+			Utf8Utils::collectCodepoints( $originalString, $position, $predicateFn ),
+			$newString
+		);
+		$this->assertEquals( $position, $newPosition );
+	}
+
+	/**
+	 * @covers ::isHttpWhitespace
+	 * @dataProvider provideIsHttpWhitespace
+	 */
+	public function testIsHttpWhitespace(
+		string $input,
+		bool $expected
+	): void {
+		$this->assertEquals( $expected, Utf8Utils::isHttpWhitespace( $input ) );
+	}
+
+	public function provideTrimHttpWhitespace(): array {
+		return [
+			[ '', '' ],
+			[ ' test ', 'test' ],
+		];
+	}
+
+	public function provideCollectCodepoints(): array {
+		return [
+			[ '', 0, '', 0, fn() => true ],
+			[ '1234test', 0, '1234', 4, fn(string $s) => \ctype_digit($s)],
+			[ 'test1234', 0, 'test', 4, fn(string $s) => \ctype_alpha($s)],
+			[ 'foo/bar', 0, 'foo', 3, fn(string $s) => $s !== '/' ],
+			[ 'foo/bar;', 0, 'foo/bar', 7, fn(string $s) => $s !== ';' ],
+		];
+	}
+
+	public function provideIsHttpWhitespace(): array {
+		return [
+			[ '\n', true ],
+			[ '\r', true ],
+			[ '\t', true ],
+			[ ' ', true ],
+			[ 't', false ],
+		];
+	}
+}

--- a/tests/Utf8UtilsTest.php
+++ b/tests/Utf8UtilsTest.php
@@ -40,6 +40,29 @@ class Utf8UtilsTest extends TestCase {
 	}
 
 	/**
+	 * @covers ::collectHttpQuotedString
+	 * @dataProvider provideCollectHttpQuotedString
+	 */
+	public function testCollectHttpQuotedString(
+		string $input,
+		int $startingPosition,
+		bool $shouldExtractValue,
+		string $expectedOutput,
+		int $expectedFinalPosition,
+	): void {
+		$position = $startingPosition;
+
+		$this->assertEquals(
+			$expectedOutput,
+			Utf8Utils::collectHttpQuotedString( $input, $position, $shouldExtractValue )
+		);
+		$this->assertEquals(
+			$expectedFinalPosition,
+			$position,
+		);
+	}
+
+	/**
 	 * @covers ::collectCodepoints
 	 * @dataProvider provideCollectCodepoints
 	 */
@@ -117,6 +140,32 @@ class Utf8UtilsTest extends TestCase {
 			[ '', '' ],
 			[ ' test ', 'test' ],
 			[ '      ', '' ],
+		];
+	}
+
+	public function provideCollectHttpQuotedString(): array {
+		return [
+			[
+				"\"\\",
+				0,
+				false,
+				"\"\\",
+				2,
+			],
+			[
+				"\"Hello\" World",
+				0,
+				false,
+				"\"Hello\"",
+				7,
+			],
+			[
+				"\"Hello \\\\ World\\\"\"",
+				0,
+				false,
+				"\"Hello \\\\ World\\\"\"",
+				18,
+			]
 		];
 	}
 

--- a/tests/Utf8UtilsTest.php
+++ b/tests/Utf8UtilsTest.php
@@ -2,6 +2,7 @@
 
 namespace Neoncitylights\MediaType\Tests;
 
+use IntlChar;
 use Neoncitylights\MediaType\Utf8Utils;
 use PHPUnit\Framework\TestCase;
 
@@ -9,6 +10,21 @@ use PHPUnit\Framework\TestCase;
  * @coversDefaultClass \Neoncitylights\MediaType\Utf8Utils
  */
 class Utf8UtilsTest extends TestCase {
+	/**
+	 * @covers ::onlyContains
+	 * @dataProvider provideOnlyContains
+	 */
+	public function testOnlyContains(
+		string $input,
+		callable $predicateFn,
+		bool $expected
+	): void {
+		$this->assertEquals(
+			$expected,
+			Utf8Utils::onlyContains( $input, $predicateFn )
+		);
+	}
+
 	/**
 	 * @covers ::trimHttpWhitespace
 	 * @dataProvider provideTrimHttpWhitespace
@@ -37,10 +53,38 @@ class Utf8UtilsTest extends TestCase {
 		$position = $originalPosition;
 
 		$this->assertEquals(
-			Utf8Utils::collectCodepoints( $originalString, $position, $predicateFn ),
-			$newString
+			$newString,
+			Utf8Utils::collectCodepoints( $originalString, $position, $predicateFn )
 		);
 		$this->assertEquals( $position, $newPosition );
+	}
+
+	/**
+	 * @covers ::isHttpTokenCodepoint
+	 * @dataProvider provideIsHttpTokenCodepoint
+	 */
+	public function testIsHttpTokenCodepoint(
+		string $codepoint,
+		bool $expected
+	): void {
+		$this->assertEquals(
+			$expected,
+			Utf8Utils::isHttpTokenCodepoint( $codepoint )
+		);
+	}
+
+	/**
+	 * @covers ::isHttpQuotedStringTokenCodepoint
+	 * @dataProvider provideIsHttpQuotedStringTokenCodepoint
+	 */
+	public function testIsHttpQuotedStringTokenCodepoint(
+		string $codepoint,
+		bool $expected
+	): void {
+		$this->assertEquals(
+			$expected,
+			Utf8Utils::isHttpQuotedStringTokenCodepoint( $codepoint )
+		);
 	}
 
 	/**
@@ -51,23 +95,55 @@ class Utf8UtilsTest extends TestCase {
 		string $input,
 		bool $expected
 	): void {
-		$this->assertEquals( $expected, Utf8Utils::isHttpWhitespace( $input ) );
+		$this->assertEquals(
+			$expected,
+			Utf8Utils::isHttpWhitespace( $input )
+		);
+	}
+
+	public function provideOnlyContains(): array {
+		return [
+			[ '', fn( string $c ) => \ctype_alpha( $c ), true ],
+			[ 'test', fn( string $c ) => \ctype_alpha( $c ), true ],
+			[ '1234', fn( string $c ) => \ctype_digit( $c ), true ],
+			[ '1234test', fn( string $c ) => \ctype_digit( $c ), false ],
+			[ 'test1234', fn( string $c ) => \ctype_alpha( $c ), false ],
+			[ 'test1234', fn( string $c ) => \ctype_alnum( $c ), true ],
+		];
 	}
 
 	public function provideTrimHttpWhitespace(): array {
 		return [
 			[ '', '' ],
 			[ ' test ', 'test' ],
+			[ '      ', '' ],
 		];
 	}
 
 	public function provideCollectCodepoints(): array {
 		return [
 			[ '', 0, '', 0, fn() => true ],
-			[ '1234test', 0, '1234', 4, fn(string $s) => \ctype_digit($s)],
-			[ 'test1234', 0, 'test', 4, fn(string $s) => \ctype_alpha($s)],
-			[ 'foo/bar', 0, 'foo', 3, fn(string $s) => $s !== '/' ],
-			[ 'foo/bar;', 0, 'foo/bar', 7, fn(string $s) => $s !== ';' ],
+			[ '1234test', 0, '1234', 4, fn( string $s ) => \ctype_digit( $s ) ],
+			[ 'test1234', 0, 'test', 4, fn( string $s ) => \ctype_alpha( $s ) ],
+			[ 'foo/bar', 0, 'foo', 3, fn( string $s ) => $s !== '/' ],
+			[ 'foo/bar;', 0, 'foo/bar', 7, fn( string $s ) => $s !== ';' ],
+		];
+	}
+
+	public function provideIsHttpTokenCodepoint(): array {
+		return [
+			[ IntlChar::chr( 0x24 ), true ],
+			[ IntlChar::chr( 0x28 ), false ],
+		];
+	}
+
+	public function provideIsHttpQuotedStringTokenCodepoint(): array {
+		return [
+			[ IntlChar::chr( 0x20 ), true ],
+			[ IntlChar::chr( 0x21 ), true ],
+			[ IntlChar::chr( 0x22 ), false ],
+			[ IntlChar::chr( 0x5C ), false ],
+			[ IntlChar::chr( 0x7F ), false ],
 		];
 	}
 


### PR DESCRIPTION
The API `MediaType::newFromString()` was a simple parser, but unfortunately a bit naive because of it's simplicity. It (mostly) did a simple string split at `/`, `;`, and `=`. Unfortunately it didn't account for many things, which the new parser now fixes and replaces.

## New parser
 - validates for Unicode ranges of HTTP codepoints and HTTP quoted-string codepoints
 - normalizes the type and subtype to ASCII lowercase
 - is more forgiving with surrounding HTTP whitespace codepoints
 - accounts for HTTP-quoted strings in parameter values, and normalizes such values
 - will error out when the type or subtype is empty

## API changes
 - Breaking change: `MediaType::newFromString()` is removed.
 - Fix: Makes `MediaType` serialization more compliant (`MediaType::__toString()`)
 - Feat: `MediaTypeParser::parseOrNull()` replaces `MediaType::newFromString()`. 
 - Feat: `MediaTypeParser::parse()` allows for throwing informative exceptions through `MediaTypeParserException` on what kind of error occured when trying to parse a potential media type value.
 
## Notes
 - `Neoncitylights\MediaType\Token` is internal (and marked with `@internal`).
 - `Neoncitylights\MediaType\Utf8Utils` is internal (and marked with `@internal`). It may be partially or fully extracted into a separate Composer package in the future.
