### PR TITLE
chore: mark properties as public+readonly in MediaType

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,10 @@ use Neoncitylights\MediaType\MediaTypeParser;
 $parser = new MediaTypeParser();
 $mediaType = $parser->parseOrNull( 'text/plain;charset=UTF-8' );
 
-print( $mediaType->getType() );
-// 'text'
-
-print( $mediaType->getSubType() );
-// 'plain'
-
-print( $mediaType->getEssence() );
-// 'text/plain'
-
-print( $mediaType->getParameterValue( 'charset' ) );
-// 'UTF-8'
+print( $mediaType->type ); // 'text'
+print( $mediaType->subType ); // 'plain'
+print( $mediaType->getEssence() ); // 'text/plain'
+print( $mediaType->getParameterValue( 'charset' ) ); // 'UTF-8'
 ```
 
 ## License

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -11,22 +11,31 @@ use Stringable;
  */
 class MediaType implements Stringable {
 	/**
+	 * Gives the first portion of a media type's essence.
+	 * e.g, if given 'text/plain', it will return 'text'.
+	 *
 	 * @see https://mimesniff.spec.whatwg.org/#type
 	 * @var string
 	 */
-	private $type;
+	public readonly string $type;
 
 	/**
+	 * Gives the second portion of a media type's essence.
+	 * e.g, if given 'text/plain', it will return 'plain'.
+	 *
 	 * @see https://mimesniff.spec.whatwg.org/#subtype
 	 * @var string
 	 */
-	private $subType;
+	public readonly string $subType;
 
 	/**
+	 * Gives an array of parameters of a media type,
+	 * if any parameters exist. Otherwise, it will return an empty array.
+	 *
 	 * @see https://mimesniff.spec.whatwg.org/#parameters
 	 * @var string[]
 	 */
-	private $parameters;
+	public readonly array $parameters;
 
 	/**
 	 * @param string $type
@@ -40,28 +49,6 @@ class MediaType implements Stringable {
 	}
 
 	/**
-	 * Gives the first portion of a media type's essence.
-	 * e.g, if given 'text/plain', it will return 'text'.
-	 *
-	 * @see https://mimesniff.spec.whatwg.org/#type
-	 * @return string
-	 */
-	public function getType(): string {
-		return $this->type;
-	}
-
-	/**
-	 * Gives the second portion of a media type's essence.
-	 * e.g, if given 'text/plain', it will return 'plain'.
-	 *
-	 * @see https://mimesniff.spec.whatwg.org/#subtype
-	 * @return string
-	 */
-	public function getSubType(): string {
-		return $this->subType;
-	}
-
-	/**
 	 * Gives the type and subtype of a media type.
 	 * e.g, if given 'text/plain;charset=UTF-8', it will return 'text/plain'.
 	 *
@@ -70,17 +57,6 @@ class MediaType implements Stringable {
 	 */
 	public function getEssence(): string {
 		return "{$this->type}/{$this->subType}";
-	}
-
-	/**
-	 * Gives an array of parameters of a media type,
-	 * if any parameters exist. Otherwise, it will return an empty array.
-	 *
-	 * @see https://mimesniff.spec.whatwg.org/#parameters
-	 * @return array
-	 */
-	public function getParameters(): array {
-		return $this->parameters;
 	}
 
 	/**
@@ -104,15 +80,15 @@ class MediaType implements Stringable {
 	 * @see https://mimesniff.spec.whatwg.org/#image-mime-type
 	 */
 	public function isImage(): bool {
-		return $this->getType() === 'image';
+		return $this->type === 'image';
 	}
 
 	/**
 	 * https://mimesniff.spec.whatwg.org/#audio-or-video-mime-type
 	 */
 	public function isAudioOrVideo(): bool {
-		return $this->getType() === 'video'
-			|| $this->getType() === 'audio'
+		return $this->type === 'video'
+			|| $this->type === 'audio'
 			|| $this->getEssence() === 'application/ogg';
 	}
 
@@ -120,9 +96,9 @@ class MediaType implements Stringable {
 	 * @see https://mimesniff.spec.whatwg.org/#font-mime-type
 	 */
 	public function isFont(): bool {
-		return $this->getType() === 'font'
-			|| ( $this->getType() === 'application'
-			&& \in_array( $this->getSubType(), [
+		return $this->type === 'font'
+			|| ( $this->type === 'application'
+			&& \in_array( $this->subType, [
 				'font-cff',
 				'font-off',
 				'font-sfnt',
@@ -137,7 +113,7 @@ class MediaType implements Stringable {
 	 * @see https://mimesniff.spec.whatwg.org/#zip-based-mime-type
 	 */
 	public function isZipBased(): bool {
-		return \str_ends_with( $this->getSubType(), '+zip' )
+		return \str_ends_with( $this->subType, '+zip' )
 			|| $this->getEssence() === 'application/zip';
 	}
 
@@ -145,15 +121,15 @@ class MediaType implements Stringable {
 	 * @see https://mimesniff.spec.whatwg.org/#archive-mime-type
 	 */
 	public function isArchive(): bool {
-		return $this->getType() === 'application'
-			&& \in_array( $this->getSubType(), [ 'x-rar-compressed', 'zip', 'x-gzip' ] );
+		return $this->type === 'application'
+			&& \in_array( $this->subType, [ 'x-rar-compressed', 'zip', 'x-gzip' ] );
 	}
 
 	/**
 	 * @see https://mimesniff.spec.whatwg.org/#xml-mime-type
 	 */
 	public function isXml(): bool {
-		return \str_ends_with( $this->getSubType(), '+xml' )
+		return \str_ends_with( $this->subType, '+xml' )
 			|| $this->getEssence() === 'text/xml'
 			|| $this->getEssence() === 'application/xml';
 	}
@@ -181,16 +157,16 @@ class MediaType implements Stringable {
 	 */
 	public function isJavaScript(): bool {
 		return (
-				$this->getType() === 'application'
-				&& \in_array( $this->getSubType(), [
+				$this->type === 'application'
+				&& \in_array( $this->subType, [
 					'ecmascript',
 					'javascript',
 					'x-ecmascript',
 					'x-javascript'
 				] ) )
 			|| (
-				$this->getType() === 'text'
-				&& \in_array( $this->getSubType(), [
+				$this->type === 'text'
+				&& \in_array( $this->subType, [
 					'ecmascript',
 					'javascript',
 					'javascript1.0',
@@ -210,7 +186,7 @@ class MediaType implements Stringable {
 	 * @see https://mimesniff.spec.whatwg.org/#json-mime-type
 	 */
 	public function isJson(): bool {
-		return \str_ends_with( $this->getSubType(), '+json' )
+		return \str_ends_with( $this->subType, '+json' )
 			|| $this->getEssence() === 'application/json'
 			|| $this->getEssence() === 'text/json';
 	}
@@ -221,12 +197,12 @@ class MediaType implements Stringable {
 	 */
 	public function __toString(): string {
 		$essence = $this->getEssence();
-		if ( $this->getParameters() === [] ) {
+		if ( $this->parameters === [] ) {
 			return $essence;
 		}
 
 		$serializedParameters = '';
-		foreach ( $this->getParameters() as $parameter => $value ) {
+		foreach ( $this->parameters as $parameter => $value ) {
 			$serializedParameters .= ";{$parameter}=";
 			$serializedValue = $value;
 

--- a/tests/MediaTypeParserTest.php
+++ b/tests/MediaTypeParserTest.php
@@ -30,9 +30,9 @@ class MediaTypeParserTest extends TestCase {
 		$parsedValue = $this->parser->parse( $validMediaType );
 
 		$this->assertInstanceOf( MediaType::class, $parsedValue );
-		$this->assertEquals( $expectedType, $parsedValue->getType() );
-		$this->assertEquals( $expectedSubType, $parsedValue->getSubType() );
-		$this->assertEquals( $expectedParameters, $parsedValue->getParameters() );
+		$this->assertEquals( $expectedType, $parsedValue->type );
+		$this->assertEquals( $expectedSubType, $parsedValue->subType );
+		$this->assertEquals( $expectedParameters, $parsedValue->parameters );
 	}
 
 	/**

--- a/tests/MediaTypeTest.php
+++ b/tests/MediaTypeTest.php
@@ -20,28 +20,6 @@ class MediaTypeTest extends TestCase {
 	}
 
 	/**
-	 * @covers ::getType
-	 * @dataProvider provideTypes
-	 */
-	public function testGetType( string $subType, string $type ): void {
-		$this->assertEquals(
-			$type,
-			( new MediaType( $type, $subType, [] ) )->getType()
-		);
-	}
-
-	/**
-	 * @covers ::getSubType
-	 * @dataProvider provideSubTypes
-	 */
-	public function testGetSubType( string $subType, string $type ): void {
-		$this->assertEquals(
-			$subType,
-			( new MediaType( $type, $subType, [] ) )->getSubType()
-		);
-	}
-
-	/**
 	 * @covers ::getEssence
 	 * @dataProvider provideEssences
 	 */
@@ -49,22 +27,6 @@ class MediaTypeTest extends TestCase {
 		$this->assertEquals(
 			$expectedEssence,
 			( new MediaType( $type, $subType, [] ) )->getEssence()
-		);
-	}
-
-	/**
-	 * @covers ::getParameters
-	 * @dataProvider provideParameters
-	 */
-	public function testGetParameters(
-		string $type,
-		string $subType,
-		array $givenParameters,
-		array $expectedParameters
-	): void {
-		$this->assertEquals(
-			$expectedParameters,
-			( new MediaType( $type, $subType, $givenParameters ) )->getParameters()
 		);
 	}
 
@@ -104,40 +66,6 @@ class MediaTypeTest extends TestCase {
 	public function provideInvalidMediaTypes() {
 		return [
 			[ '' ],
-		];
-	}
-
-	public function provideTypes() {
-		return [
-			[
-				'text',
-				'text/plain',
-			],
-			[
-				'application',
-				'application/xhtml+xml',
-			],
-			[
-				'application',
-				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-			],
-		];
-	}
-
-	public function provideSubTypes() {
-		return [
-			[
-				'plain',
-				'text/plain',
-			],
-			[
-				'xhtml+xml',
-				'application/xhtml+xml',
-			],
-			[
-				'vnd.openxmlformats-officedocument.presentationml.presentation',
-				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-			],
 		];
 	}
 


### PR DESCRIPTION
Getter methods in MediaType are now removed and replaced with public+readonly properties.