### PR TITLE
docs: remove redundant `@param` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixes minor phpDoc annotation issues within `MediaType`. Specifically:
   - Removes redundant `@return` annotations that are already specified from return typehints
+  - Removes redundant `@param` annotation from `getParameterValue()`
   - Adds missing `@see` annotation to `isAudioOrVideo()` method in reference to a WHATWG Standard link
 
 ## 2.0.0 (2023-12-11)

--- a/src/MediaType.php
+++ b/src/MediaType.php
@@ -63,8 +63,6 @@ final class MediaType implements Stringable {
 	 * if that parameter exists; otherwise, it will return a null value.
 	 * e.g, if given a media type of 'text/plain;charset=UTF-8', and the
 	 * given parameter is 'charset', it will return 'UTF-8'.
-	 *
-	 * @param string $parameterName
 	 */
 	public function getParameterValue( string $parameterName ): ?string {
 		if ( !\array_key_exists( $parameterName, $this->parameters ) ) {


### PR DESCRIPTION
Followup to d878e57 / #42